### PR TITLE
fix key input for international keyboard layouts

### DIFF
--- a/static/game.js
+++ b/static/game.js
@@ -64,7 +64,7 @@ Array.from(document.querySelectorAll('.all-letters .letter')).forEach((letterEl)
 
 document.body.addEventListener('keydown', (e) => {
     if (/^Key([A-Z]$)/.test(e.code)) {
-        handleKeyboardEntry(e.code[3].toLocaleLowerCase())
+        handleKeyboardEntry(e.key.toLocaleLowerCase())
     } else if (e.code === 'Backspace') {
         handleKeyboardEntry('del')
     } else if (e.code === 'Enter') {


### PR DESCRIPTION
Hey 👋  Please let me say that I have so much fun playing this and I'm totally procrastinating and wasting time with it. And that's something I'm in dire need of! Thank you for doing this!

I'm proposing a change that listens to the `key` rather than the `code` in the keyboard event. My German keyboard layout casts a `KeyY` code, but the key is actually `z`. This messes up my `PARTY` ;-) I'm sure other layouts have similar issues. Hope this helps!

And thank you again, it's really, really, really fun!